### PR TITLE
fix: wow.exe check

### DIFF
--- a/epoch-updater.sh
+++ b/epoch-updater.sh
@@ -50,7 +50,7 @@ fi
 
 
 # Check if Wow.exe exists in current directory (case-insensitive)
-if ! find . -maxdepth 1 -iname 'wow.exe' -type f -print -quit >/dev/null 2>&1; then
+if [ -z "$(find . -maxdepth 1 -iname 'wow.exe' -type f -print -quit 2>/dev/null)" ]; then
     zenity --error \
         --title="Project Epoch Updater" \
         --text="Wow.exe not found in current directory!\n\nPlease run this updater from your World of Warcraft directory." \


### PR DESCRIPTION
`if ! find . -maxdepth 1 -iname 'wow.exe' -type f -print -quit >/dev/null 2>&1; then`
the previous condition used to check the exit code of find, but find returns exit code 0 even if it finds nothing as long as the command runs successfully.

The new one checks the output instead.

Anyway thanks for the script